### PR TITLE
Changepassword command

### DIFF
--- a/masterfirefoxos/settings/base.py
+++ b/masterfirefoxos/settings/base.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'feincms.module.page',
     'feincms.module.medialibrary',
     'foundation',
+    'django_stackato',
 
     # Django apps
     'django.contrib.admin',

--- a/requirements.txt
+++ b/requirements.txt
@@ -117,3 +117,5 @@ feedparser==5.1.3
 # sha256: clGEm-hrnuwAgsKujDTMJ3Y8Mfzts66KMDST95y-x-0
 django-zurb-foundation==5.4.5
 
+# sha256: CJ37xCfPCbXyVzLjbQe-Nz1rL97SbK7cG4s0Qfgc6ec
+django-stackato==1.0


### PR DESCRIPTION
Because Deis doesn't support interactive shells (yet) we cannot run `createsuperuser` without `--noinput` and therefore we cannot set the superuser password. Similarly for `changepassword` command. This package adds a `changepassword2` command which reads the password from the command line. To create a user

```
deis run -- ./manage.py createsuperuser --username foo --email foo@example.com --noinput
deis run -- ./manage.py changepassword2 foo 123
```

The alternative is to directly ssh into a coreos host and run manage cmds but I'd like to avoid that and instead provide a deis way to do this. What do you think @jgmize?
