### PR TITLE
Static Files Cache and GZIP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ADD ./requirements.txt /app/requirements.txt
 ADD ./bin/peep.py /app/bin/peep.py
 RUN ./bin/peep.py install -r requirements.txt
 
-COPY ./.git/HEAD /app/static/revision.txt
 ADD . /app
+COPY ./.git/HEAD /app/masterfirefoxos/base/static/revision.txt
 
 EXPOSE 80
 

--- a/masterfirefoxos/base/static/revision.txt
+++ b/masterfirefoxos/base/static/revision.txt
@@ -1,0 +1,1 @@
+# Placeholder. Will be replaced by docker build.

--- a/masterfirefoxos/settings/base.py
+++ b/masterfirefoxos/settings/base.py
@@ -104,6 +104,7 @@ USE_TZ = config('USE_TZ', default=True, cast=bool)
 
 STATIC_ROOT = config('STATIC_ROOT', default=os.path.join(BASE_DIR, 'static'))
 STATIC_URL = config('STATIC_URL', '/static/')
+STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 
 MEDIA_ROOT = config('MEDIA_ROOT', default=os.path.join(BASE_DIR, 'media'))
 MEDIA_URL = config('MEDIA_URL', '/media/')

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,11 +36,9 @@ MarkupSafe==0.23
 # sha256: _7QRdX3jdNBcdZySmQjSOXxm47z2813uQabvnrhRSXs
 gunicorn==19.1.1
 
-# TarGZ
-# sha256: pNxeBMs75dG-9lGXFXl4Md77FtMB5193l85wxnyeNbo
-# Wheel
-# sha256: AQYO48CTYIdztcrXXioWrKd5GJDyQQgFOsNNB7Sd4Uk
-whitenoise==1.0.4
+# sha256: 2slBnbPs4nu1PHQzJD_CLtQs9o3p1sQSk5Dh2a7-YxA
+# sha256: Pk2AGZlglZuCiVGqJMv6o2zr7RSdzXKMEehVeYsV-HA
+whitenoise==1.0.6
 
 # sha256: 0yV2uq13_dnmhZvpfCtqPBem9IQ2Q4nbcx8Gl7ehlmE
 django-csp==2.0.3


### PR DESCRIPTION
Enable Whitenoise's caching [0] for static files. This requires to upgrade whitenoise to 1.0.6 to fix an error with static files with zero length.

[0] http://whitenoise.readthedocs.org/en/latest/django.html#add-gzip-and-caching-support