### PR TITLE
Add revision.txt to masterfirefoxos/base/static

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ADD ./requirements.txt /app/requirements.txt
 ADD ./bin/peep.py /app/bin/peep.py
 RUN ./bin/peep.py install -r requirements.txt
 
-COPY ./.git/HEAD /app/static/revision.txt
 ADD . /app
+COPY ./.git/HEAD /app/masterfirefoxos/base/static/revision.txt
 
 EXPOSE 80
 

--- a/masterfirefoxos/base/static/revision.txt
+++ b/masterfirefoxos/base/static/revision.txt
@@ -1,0 +1,1 @@
+# Placeholder. Will be replaced by docker build.


### PR DESCRIPTION
Management command collectstatic will overwrite 'static' directory and delete revision.txt. Instead of directly writing revision.txt to static, make it part of masterfirefoxo.base app.

Test: http://giorgos-dev.masterfirefoxos.com/static/revision.txt