### PR TITLE
Move collectstatic to run-docker.sh

### DIFF
--- a/bin/run-common.sh
+++ b/bin/run-common.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-./manage.py collectstatic --noinput -c
 ./manage.py syncdb --noinput
 

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 ./bin/run-common.sh
+./manage.py collectstatic --noinput -c
 gunicorn masterfirefoxos.wsgi:application -b 0.0.0.0:80 -w 2 --log-file -


### PR DESCRIPTION
AFAICT we shouldn't need to run the collectstatic command  during a 'fig up', only for production deploys. This will eliminate the annoyance of it deleting the static/.gitkeep file every time.