### PR TITLE
collectstatic does not need -c

### DIFF
--- a/bin/run-common.sh
+++ b/bin/run-common.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-./manage.py collectstatic --noinput -c
 ./manage.py syncdb --noinput
 ./manage.py compilemessages

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 ./bin/run-common.sh
+./manage.py collectstatic --noinput
 gunicorn masterfirefoxos.wsgi:application -b 0.0.0.0:80 -w 2 --log-file -


### PR DESCRIPTION
Running 'collectstatic -c' without having a STATIC directory raises
Exception. We can safely remove -c since we run the command in a docker
container that does not have STATIC directory.