### PR TITLE
Set revision.txt on both `git push` and `deis pull`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN ./bin/peep.py install -r requirements.txt
 ADD https://github.com/mozilla/masterfirefoxos-l10n/archive/master.tar.gz /tmp/locale.tar.gz
 RUN mkdir -p /app/locale && tar zxf /tmp/locale.tar.gz -C /app/locale --strip-components 1
 COPY . /app
-COPY ./.git/HEAD /app/masterfirefoxos/base/static/revision.txt
 
 EXPOSE 80
 

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+
+if [ -e ./.git/HEAD ]
+then
+    cp ./.git/HEAD /app/masterfirefoxos/base/static/revision.txt
+else
+    echo $GIT_SHA > /app/masterfirefoxos/base/static/revision.txt
+fi
+
 ./bin/run-common.sh
 ./manage.py collectstatic --noinput
 gunicorn masterfirefoxos.wsgi:application -b 0.0.0.0:80 -w 2 --log-file -

--- a/masterfirefoxos/base/static/revision.txt
+++ b/masterfirefoxos/base/static/revision.txt
@@ -1,1 +1,1 @@
-# Placeholder. Will be replaced by docker build.
+# Placeholder. Will be replaced by ./bin/run-docker.sh


### PR DESCRIPTION
When using `git push` to push code to deis there is no git repository
and therefore we cannot use git command to get the latest SHA. Instead
we can use GIT_SHA env variable, which is automatically set by Deis.

When using `deis pull` we can still rely on git.

We moved the code that sets revision.txt to run-docker.sh to set
revision.txt based on the environment.