### PR TITLE
Add pontoon.

### DIFF
--- a/masterfirefoxos/base/helpers.py
+++ b/masterfirefoxos/base/helpers.py
@@ -62,3 +62,8 @@ def get_image_url(img, geometry=None, locale=None):
     # AWS S3 urls contain AWS_ACCESS_KEY_ID, Expiration and other
     # params. We don't need them.
     return url.split('?')[0]
+
+
+@register.function
+def include_pontoon(request):
+    return request.get_host() == getattr(settings, 'LOCALIZATION_HOST', None)

--- a/masterfirefoxos/base/templates/base.html
+++ b/masterfirefoxos/base/templates/base.html
@@ -28,6 +28,7 @@
 
     {% block google_analytics %}
     {% endblock %}
+
   </head>
   <body id="{% block body_id %}{% endblock %}" class="no-js {% block body_class %}{% endblock %}">
     <div id="outer-wrapper">
@@ -117,5 +118,9 @@
       <script src="{{ static('js/libs/jquery-2.1.0.min.js') }}"></script>
       <!--<![endif]-->
     {% endblock %}
+    {% if include_pontoon(request) %}
+      <script src="https://pontoon.mozilla.org/pontoon.js"></script>
+    {% endif %}
+
   </body>
 </html>

--- a/masterfirefoxos/settings/base.py
+++ b/masterfirefoxos/settings/base.py
@@ -72,7 +72,6 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'csp.middleware.CSPMiddleware',
     'masterfirefoxos.base.middleware.NonExistentLocaleRedirectionMiddleware',
 )

--- a/masterfirefoxos/settings/base.py
+++ b/masterfirefoxos/settings/base.py
@@ -124,7 +124,9 @@ TEMPLATE_LOADERS = (
 CSP_DEFAULT_SRC = (
     "'self'",
     "https://*.youtube.com",
-    "http://*.youtube.com"
+    "http://*.youtube.com",
+    'https://pontoon.mozilla.org',
+    'https://pontoon-dev.allizom.org',
 )
 CSP_FONT_SRC = (
     "'self'",
@@ -137,6 +139,8 @@ CSP_IMG_SRC = (
     'https://*.mozilla.net',
     'https://masterfirefoxos-dev.s3.amazonaws.com',
     'https://masterfirefoxos-prod.s3.amazonaws.com',
+    'https://pontoon.mozilla.org',
+    'https://pontoon-dev.allizom.org',
 )
 CSP_SCRIPT_SRC = (
     "'self'",
@@ -144,6 +148,8 @@ CSP_SCRIPT_SRC = (
     'https://www.mozilla.org',
     'http://*.mozilla.net',
     'https://*.mozilla.net',
+    'https://pontoon.mozilla.org',
+    'https://pontoon-dev.allizom.org',
 )
 CSP_STYLE_SRC = (
     "'self'",
@@ -152,6 +158,8 @@ CSP_STYLE_SRC = (
     'https://www.mozilla.org',
     'http://*.mozilla.net',
     'https://*.mozilla.net',
+    'https://pontoon.mozilla.org',
+    'https://pontoon-dev.allizom.org',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (
@@ -233,4 +241,7 @@ def media_files_unique_path(instance, filename):
 
 FEINCMS_MEDIALIBRARY_UPLOAD_TO = media_files_unique_path
 
+
 THUMBNAIL_PRESERVE_FORMAT = True
+
+LOCALIZATION_HOST = config('LOCALIZATION_HOST', default=None)


### PR DESCRIPTION
Pontoon needs us to include `pontoon.js` in `base.html` to operate. Also needs some CSP rules.

To avoid including pontoon.js in all requests, we check the host on which we received the request on. If the host matches `settings.LOCALIZATION_HOST` then we include it.

We need to configure:
 - [x] ALLOWED_HOSTS to include pontoon.masterfirefoxos.com
 - [x] set LOCALIZATION_HOST to pontoon.masterfirefoxos.com
 - [ ] Include pontoon.masterfirefoxos.com to domains of `masterfirefoxos-prod` app (after we merge this, we need to remove the domain from `giorgos-dev` app first)