### PR TITLE
[TinyMCE] Set entity_encoding and extended_valid_elements.

### DIFF
--- a/masterfirefoxos/base/static/js/init_tinymce.js
+++ b/masterfirefoxos/base/static/js/init_tinymce.js
@@ -7,6 +7,8 @@
       paste_auto_cleanup_on_paste: false,
       relative_urls: false,
       invalid_elements: 'script',
+      entity_encoding : "raw",
+      extended_valid_elements : "-p",
       plugins: [
         "code", "link"
       ],


### PR DESCRIPTION
raw:
All characters will be stored in non-entity form except these
XML default entities: &amp; &lt; &gt; &quot;

extended_valid_elements: "-p",
Remove empty paragraphs, i.e. <p> </p>

More info
 http://www.tinymce.com/wiki.php/Configuration:entity_encoding
 http://www.tinymce.com/wiki.php/Configuration:valid_elements#Default_rule_set