### PR TITLE
Fix Bug 1126864: Added Just UA GA, Adjusted CSP To Work

### DIFF
--- a/masterfirefoxos/base/templates/base.html
+++ b/masterfirefoxos/base/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ LANG }}" dir="{{ DIR }}" class="no-js" data-ga-code="GA_ACCOUNT_CODE">
+<html lang="{{ LANG }}" dir="{{ DIR }}" class="no-js">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0">
@@ -26,8 +26,15 @@
       <link rel="stylesheet" type="text/css" href="{{ static('css/oldIE.css') }}">
     <![endif]-->
 
-    {% block google_analytics %}
-    {% endblock %}
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-35433268-38', 'auto');
+      ga('send', 'pageview');
+    </script>
 
   </head>
   <body id="{% block body_id %}{% endblock %}" class="{% block body_class %}{% endblock %}">

--- a/masterfirefoxos/settings/base.py
+++ b/masterfirefoxos/settings/base.py
@@ -140,15 +140,20 @@ CSP_IMG_SRC = (
     'https://masterfirefoxos-prod.s3.amazonaws.com',
     'https://pontoon.mozilla.org',
     'https://pontoon-dev.allizom.org',
+    'https://www.google-analytics.com',
+    'http://www.google-analytics.com',
 )
 CSP_SCRIPT_SRC = (
     "'self'",
+    "'unsafe-inline'",
     'http://www.mozilla.org',
     'https://www.mozilla.org',
     'http://*.mozilla.net',
     'https://*.mozilla.net',
     'https://pontoon.mozilla.org',
     'https://pontoon-dev.allizom.org',
+    'https://www.google-analytics.com',
+    'http://www.google-analytics.com',
 )
 CSP_STYLE_SRC = (
     "'self'",


### PR DESCRIPTION
I added this directly to base.html, I did not see an advantage to having this in a sep js file.

Note the csp values to get this to work, i think unsafe inline is OK here because its only unsafe-inline against specific urls (I think.. CSP documentation is not so good).

If you are testing locally and see a CSP error its probably caused by bug 1132538