### PR TITLE
 [fix bug 1132883] Check if menu-icon exists before using it. 

### DIFF
--- a/masterfirefoxos/base/static/js/main.js
+++ b/masterfirefoxos/base/static/js/main.js
@@ -8,11 +8,12 @@
     // Add class to reflect javascript availability for CSS
     document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/, 'js');
 
-
-    document.querySelector('.menu-icon').onclick = function() {
-        return false;
-    };
-
+    var menu_icon = document.querySelector('.menu-icon');
+    if (menu_icon) {
+        menu_icon.onclick = function() {
+            return false;
+        };
+    }
 
     function selectChangeLocation(id) {
         var select = document.getElementById(id);


### PR DESCRIPTION
`.menu-icon` only exists in content templates and therefore an error is raised on pages using the home template.