### PR TITLE
Per locale and per version po(t) files.

### DIFF
--- a/bin/jenkins/makemessages.sh
+++ b/bin/jenkins/makemessages.sh
@@ -29,5 +29,6 @@ fig --project-name jenkins${JOB_NAME}${BUILD_NUMBER} run -T web ./manage.py runs
 fig --project-name jenkins${JOB_NAME}${BUILD_NUMBER} run -T web chmod a+wx -R locale
 
 cd locale
-git commit -a -m "Update strings."
+git add .
+git commit -m "Update strings."
 git push origin master


### PR DESCRIPTION
This breaks `django.po` for each locale into `common.po` and multiple `<version>.po` files based on the versions of the documentation per locale. 

E.g. for `de` three files will be created `common.po`, `1-1.po` and `2-0.po`

TODOs
 - [x] Remove django.po files. (see https://github.com/mozilla/masterfirefoxos-l10n/pull/10)
 - [x] Verify that pontoon will work with the current structure (verified with @mathjazz)
 - [ ] Build a script to merge back versioned po files into a single django.po