### PR TITLE
Adjusted which intro video gets translated.

### DIFF
--- a/masterfirefoxos/settings/base.py
+++ b/masterfirefoxos/settings/base.py
@@ -273,7 +273,7 @@ if not DEBUG:
 
 LOCALIZED_YOUTUBE_ID = {
     # 1.1
-    'z8IAfoqxOPI': {
+    'yPRIgHARJsA': {
         'hr': 'QcDS5tfALy4',
         'de': 'zu2a0FXVh8c',
         'cs': 'v1tLRWtCkEs',


### PR DESCRIPTION
This intro video is the same for each locale:
https://prod.masterfirefoxos.com/en/2-0/introduction/
https://www.youtube.com/watch?v=z8IAfoqxOPI

This intro video is translated / first video on page:
https://prod.masterfirefoxos.com/en/1-1/demo-tips/
https://www.youtube.com/watch?v=yPRIgHARJsA

