### PR TITLE
Update dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM python:3.4-wheezy
+FROM python:3.4-slim
+EXPOSE 80
+CMD ["./bin/run-docker.sh"]
+
 RUN apt-get update &&\
-    apt-get install -y --no-install-recommends libpq-dev gettext libjpeg8-dev postgresql-client sharutils &&\
-    apt-get remove mysql-common -y && apt-get autoremove -y &&\
-    apt-get upgrade -y
+    apt-get install -y --no-install-recommends build-essential python-dev libpq-dev gettext libjpeg62-turbo-dev postgresql-client sharutils &&\
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY ./requirements.txt /app/requirements.txt
@@ -12,7 +14,3 @@ RUN ./bin/peep.py install -r requirements.txt
 ADD https://github.com/mozilla/masterfirefoxos-l10n/archive/master.tar.gz /tmp/locale.tar.gz
 RUN mkdir -p /app/locale && tar zxf /tmp/locale.tar.gz -C /app/locale --strip-components 1
 COPY . /app
-
-EXPOSE 80
-
-CMD ["./bin/run-docker.sh"]


### PR DESCRIPTION
* Update to python-slim image
* Move around docker command for maximum efficiency
* Fix the docker push permission denied error.

+ docker push mozillamffos/masterfirefoxos:16229c645b118a23c3549a3144e4f1edd04c3416
The push refers to a repository [mozillamffos/masterfirefoxos] (len: 1)
Sending image list
time="2015-05-05T11:10:45Z" level="fatal" msg="Error: Status 400 trying
to push repository mozillamffos/masterfirefoxos: \"Access denied:
d8fa3e4a179365f4518490a95c9411775560999c769074dd248c65f8bd88115b is a
private image\""